### PR TITLE
- Updates the example apps with the latest SDK versions.

### DIFF
--- a/Docs.md
+++ b/Docs.md
@@ -10,7 +10,6 @@
 **Templates**
 - [GiphyDialogFragment](#giphydialogfragment)
 - [Fresco initialization](#fresco-initialization)
-- [Exoplayer cache initialization](#exoplayer-cache-initialization)
 - [Settings](#gphsettings-properties)
     - [Theme](#theme)
     - [Media Types](#media-types)
@@ -35,7 +34,7 @@
 - [Animated Text Creation](https://github.com/Giphy/giphy-android-sdk/blob/main/animate.md)
 
 ### Requirements
-- Giphy UI SDK only supports projects that have been upgraded to [androidx](https://developer.android.com/jetpack/androidx/).
+- The GIPHY UI SDK only supports projects that have been upgraded to [androidx](https://developer.android.com/jetpack/androidx/).
 - Requires minSdkVersion 19
 - A Giphy Android SDK key from the [Giphy Developer Portal](https://developers.giphy.com/dashboard/?create=true).
 
@@ -117,16 +116,6 @@ Giphy.configure(
     }
   })
 ``` 
-
-### Exoplayer cache initialization
-The SDK has `Exoplayer` video cache setup.
-It's enabled by default: the `videoCacheMaxBytes` value must be greater than 0, otherwise, the SDK will skip cache initialization and [Clips](https://github.com/Giphy/giphy-android-sdk/blob/main/clips.md) won't work.
-```kotlin
-Giphy.configure(
-  videoCacheMaxBytes: 100 * 1024 * 1024
-  )
-```
-You may want to skip this setup in case you use a different `Exoplayer` version that is incompatible with Giphy SDK but still want to get gifs from Giphy.
 
 ## GPHSettings properties
 
@@ -368,10 +357,10 @@ override fun handle(imagePipelineConfigBuilder: ImagePipelineConfig.Builder) {
 ```
 
 #### *Dependencies*
-[Fresco](https://github.com/facebook/fresco): GIF/WebP playback <br>
-[ExoPlayer](https://github.com/google/ExoPlayer): Clip playback <br>
-[Timber](https://github.com/JakeWharton/timber): Logger <br>
-[Lottie](https://github.com/JakeWharton/timber): Animations <br>
+- [Fresco](https://github.com/facebook/fresco): GIF/WebP playback <br>
+- *Removed starting from SDK v2.2.0* [ExoPlayer](https://github.com/google/ExoPlayer): Clip playback <br>
+- [Timber](https://github.com/JakeWharton/timber): Logger <br>
+- [Lottie](https://github.com/JakeWharton/timber): Animations <br>
 
 #### *Buttons*
 

--- a/Docs_Java.md
+++ b/Docs_Java.md
@@ -10,7 +10,6 @@
 **Templates**
 - [GiphyDialogFragment](#giphydialogfragment)
 - [Fresco initialization](#fresco-initialization)
-- [Exoplayer cache initialization](#exoplayer-cache-initialization)
 - [Settings](#gphsettings-properties)
   - [Theme](#theme)
   - [Media Types](#media-types)
@@ -35,7 +34,7 @@
 - [Animated Text Creation](https://github.com/Giphy/giphy-android-sdk/blob/main/animate.md)
 
 ### Requirements
-- Giphy UI SDK only supports projects that have been upgraded to [androidx](https://developer.android.com/jetpack/androidx/).
+- The Giphy UI SDK only supports projects that have been upgraded to [androidx](https://developer.android.com/jetpack/androidx/).
 - Requires minSdkVersion 19
 - A Giphy Android SDK key from the [Giphy Developer Portal](https://developers.giphy.com/dashboard/?create=true).
 
@@ -128,16 +127,6 @@ Giphy.INSTANCE.configure(DemoActivityJava.this,
             }
 });
 ```
-
-### Exoplayer cache initialization
-The SDK has `Exoplayer` video cache setup.
-It's enabled by default: the `videoCacheMaxBytes` value must be greater than 0, otherwise, the SDK will skip cache initialization and [Clips](https://github.com/Giphy/giphy-android-sdk/blob/main/clips.md) won't work.
-```kotlin
-Giphy.INSTANCE.configure(DemoActivityJava.this,
-  ...
-  100*1024*1024,
-```
-You may want to skip this setup in case you use a different `Exoplayer` version that is incompatible with Giphy SDK but still want to get gifs from Giphy.
 
 ## GPHSettings properties
 
@@ -392,10 +381,10 @@ public void handle(@NonNull ImagePipelineConfig.Builder imagePipelineConfigBuild
 ```
 
 #### *Dependencies*
-[Fresco](https://github.com/facebook/fresco): GIF/WebP playback <br>
-[ExoPlayer](https://github.com/google/ExoPlayer): Clip playback <br>
-[Timber](https://github.com/JakeWharton/timber): Logger <br>
-[Lottie](https://github.com/JakeWharton/timber): Animations <br>
+- [Fresco](https://github.com/facebook/fresco): GIF/WebP playback <br>
+- *Removed starting from SDK v2.2.0* [ExoPlayer](https://github.com/google/ExoPlayer): Clip playback <br>
+- [Timber](https://github.com/JakeWharton/timber): Logger <br>
+- [Lottie](https://github.com/JakeWharton/timber): Animations <br>
 
 #### *Buttons*
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,7 +47,9 @@ dependencies {
     implementation "androidx.appcompat:appcompat:1.1.0"
     implementation "androidx.constraintlayout:constraintlayout:1.1.3"
     implementation "com.google.android.material:material:1.1.0"
-    implementation "com.giphy.sdk:ui:2.1.18"
+    implementation "com.giphy.sdk:ui:2.2.0"
+    implementation("com.google.android.exoplayer:exoplayer-core:2.18.1")
+    implementation("com.google.android.exoplayer:exoplayer-ui:2.18.1")
     implementation 'com.github.bumptech.glide:glide:4.12.0'
     implementation "com.squareup.leakcanary:leakcanary-android:2.7"
     implementation "com.github.savvyapps:ToggleButtonLayout:1.2.0"

--- a/app/src/main/java/com/giphy/sdk/uidemo/ClipDialogFragment.kt
+++ b/app/src/main/java/com/giphy/sdk/uidemo/ClipDialogFragment.kt
@@ -5,7 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import com.giphy.sdk.core.models.Media
-import com.giphy.sdk.ui.views.GPHVideoPlayer
+import com.giphy.sdk.ui.utils.GPHAbstractVideoPlayer
 import com.giphy.sdk.uidemo.databinding.FragmentVideoPlayerBinding
 
 class ClipDialogFragment : androidx.fragment.app.DialogFragment() {
@@ -13,7 +13,7 @@ class ClipDialogFragment : androidx.fragment.app.DialogFragment() {
     lateinit var binding: FragmentVideoPlayerBinding
 
     private var media: Media? = null
-    private var videoPlayer: GPHVideoPlayer? = null
+    private var videoPlayer: GPHAbstractVideoPlayer? = null
 
     companion object {
         private val KEY_VIDEO_PLAYER = "key_video_player"
@@ -32,7 +32,7 @@ class ClipDialogFragment : androidx.fragment.app.DialogFragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        media = arguments!!.getParcelable(KEY_VIDEO_PLAYER)
+        media = requireArguments().getParcelable(KEY_VIDEO_PLAYER)
     }
 
     override fun onCreateView(
@@ -65,7 +65,7 @@ class ClipDialogFragment : androidx.fragment.app.DialogFragment() {
             media?.let { media ->
                 videoPlayerView.preloadFirstFrame(media)
                 videoPlayer?.onDestroy()
-                videoPlayer = GPHVideoPlayer(videoPlayerView, true)
+                videoPlayer = VideoPlayerExoPlayer2181Impl(videoPlayerView, true)
                 videoPlayer?.loadMedia(media)
             }
         }

--- a/app/src/main/java/com/giphy/sdk/uidemo/DemoActivity.kt
+++ b/app/src/main/java/com/giphy/sdk/uidemo/DemoActivity.kt
@@ -12,8 +12,8 @@ import com.giphy.sdk.ui.GPHSettings
 import com.giphy.sdk.ui.Giphy
 import com.giphy.sdk.ui.themes.GPHTheme
 import com.giphy.sdk.ui.themes.GridType
-import com.giphy.sdk.ui.views.GPHVideoPlayer
-import com.giphy.sdk.ui.views.GPHVideoPlayerState
+import com.giphy.sdk.ui.utils.GPHAbstractVideoPlayer
+import com.giphy.sdk.ui.utils.GPHVideoPlayerState
 import com.giphy.sdk.ui.views.GiphyDialogFragment
 import com.giphy.sdk.uidemo.VideoPlayer.VideoCache
 import com.giphy.sdk.uidemo.feed.*
@@ -38,7 +38,7 @@ class DemoActivity : AppCompatActivity() {
     //TODO: Set a valid API KEY
     val YOUR_API_KEY = INVALID_KEY
 
-    val player: GPHVideoPlayer = createVideoPlayer()
+    val player: GPHAbstractVideoPlayer = createVideoPlayer()
     private var clipsPlaybackSetting = SettingsDialogFragment.ClipsPlaybackSetting.inline
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -54,7 +54,9 @@ class DemoActivity : AppCompatActivity() {
 
         binding.launchGiphyBtn.setOnClickListener {
             player.onPause()
-            val dialog = GiphyDialogFragment.newInstance(settings.copy(selectedContentType = contentType))
+            val dialog = GiphyDialogFragment.newInstance(
+                settings.copy(selectedContentType = contentType)
+            )
             dialog.gifSelectionListener = getGifSelectionListener()
             dialog.show(supportFragmentManager, "gifs_dialog")
         }
@@ -155,8 +157,8 @@ class DemoActivity : AppCompatActivity() {
         binding.messageFeed.adapter = feedAdapter
     }
 
-    private fun createVideoPlayer(): GPHVideoPlayer {
-        val player = GPHVideoPlayer(null, true)
+    private fun createVideoPlayer(): GPHAbstractVideoPlayer {
+        val player = VideoPlayerExoPlayer2181Impl(null, true)
         player.addListener { playerState ->
             when (playerState) {
                 is GPHVideoPlayerState.MediaChanged -> {

--- a/app/src/main/java/com/giphy/sdk/uidemo/VideoPlayer/VideoPlayer.kt
+++ b/app/src/main/java/com/giphy/sdk/uidemo/VideoPlayer/VideoPlayer.kt
@@ -9,11 +9,13 @@ import android.os.Looper
 import android.os.SystemClock
 import android.view.SurfaceView
 import android.view.View
+import com.giphy.sdk.ui.utils.GPHVideoPlayerState
 import com.google.android.exoplayer2.*
 import com.google.android.exoplayer2.Player.MEDIA_ITEM_TRANSITION_REASON_REPEAT
 import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory
 import com.google.android.exoplayer2.source.ProgressiveMediaSource
 import com.google.android.exoplayer2.text.Cue
+import com.google.android.exoplayer2.text.CueGroup
 import com.google.android.exoplayer2.text.TextOutput
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
 import timber.log.Timber
@@ -38,7 +40,7 @@ sealed class VideoPlayerState {
 
 typealias PlayerStateListener = (VideoPlayerState) -> Unit
 
-class VideoPlayer : Player.Listener, TextOutput {
+class VideoPlayer : Player.Listener {
     var playerView: VideoPlayerView?
     var repeatable: Boolean
     var showCaptions: Boolean
@@ -418,9 +420,9 @@ class VideoPlayer : Player.Listener, TextOutput {
             if (repeatable) Player.REPEAT_MODE_ALL else Player.REPEAT_MODE_OFF
     }
 
-    override fun onCues(cues: MutableList<Cue>) {
+    override fun onCues(cueGroup: CueGroup) {
         listeners.forEach {
-            it(VideoPlayerState.CaptionsTextChanged(if (cues.size > 0) cues[0].text.toString() else ""))
+            it(VideoPlayerState.CaptionsTextChanged(if (cueGroup.cues.size > 0) cueGroup.cues[0].text.toString() else ""))
         }
     }
 }

--- a/app/src/main/java/com/giphy/sdk/uidemo/VideoPlayer/VideoPlayerExoPlayer2181Impl.kt
+++ b/app/src/main/java/com/giphy/sdk/uidemo/VideoPlayer/VideoPlayerExoPlayer2181Impl.kt
@@ -1,0 +1,261 @@
+package com.giphy.sdk.uidemo
+
+import android.net.Uri
+import android.view.SurfaceView
+import com.giphy.sdk.tracking.KEY_VIDEO_LENGTH
+import com.giphy.sdk.ui.utils.GPHAbstractVideoPlayer
+import com.giphy.sdk.ui.utils.GPHVideoPlayerState
+import com.giphy.sdk.ui.utils.videoUrl
+import com.giphy.sdk.ui.views.GPHVideoPlayerView
+import com.giphy.sdk.uidemo.VideoPlayer.VideoCache
+import com.google.android.exoplayer2.C
+import com.google.android.exoplayer2.DefaultLoadControl
+import com.google.android.exoplayer2.ExoPlaybackException
+import com.google.android.exoplayer2.ExoPlayer
+import com.google.android.exoplayer2.MediaItem
+import com.google.android.exoplayer2.PlaybackException
+import com.google.android.exoplayer2.Player
+import com.google.android.exoplayer2.Timeline
+import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory
+import com.google.android.exoplayer2.source.DefaultMediaSourceFactory
+import com.google.android.exoplayer2.text.CueGroup
+import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
+import timber.log.Timber
+import java.io.IOException
+
+class VideoPlayerExoPlayer2181Impl(
+    playerView: GPHVideoPlayerView?,
+    repeatable: Boolean = false,
+    showCaptions: Boolean = true
+) : GPHAbstractVideoPlayer(playerView, repeatable, showCaptions), Player.Listener {
+
+    // region Exoplayer stuff
+    private var player: ExoPlayer? = null
+
+    override val duration: Long
+        get() {
+            return player?.duration ?: 0
+        }
+    override val currentPosition: Long
+        get() {
+            return player?.currentPosition ?: 0
+        }
+    override val isPlaying: Boolean
+        get() {
+            return player?.isPlaying ?: false
+        }
+
+    override fun getVolume(): Float {
+        return player?.audioComponent?.volume ?: 0f
+    }
+
+    override fun setVolume(audioVolume: Float) {
+        val volume = if (isDeviceMuted) 0f else audioVolume
+        player?.audioComponent?.volume = volume
+        listeners.forEach {
+            it(GPHVideoPlayerState.MuteChanged(volume > 0))
+        }
+    }
+
+    override fun setVideoSurfaceView(surfaceView: SurfaceView?) {
+        player?.setVideoSurfaceView(surfaceView)
+    }
+
+    override fun seekTo(position: Long) {
+        player?.seekTo(position)
+    }
+
+    override fun play() {
+        player?.play()
+    }
+
+    override fun setupExoPlayer(playerView: GPHVideoPlayerView, autoPlay: Boolean) {
+
+        val videoUrl = media.videoUrl
+
+        if (videoUrl == null) {
+            onPlayerError(ExoPlaybackException.createForSource(IOException("Video url is null"), -1))
+        }
+
+        val loadControl = DefaultLoadControl.Builder().setPrioritizeTimeOverSizeThresholds(true)
+            .setBufferDurationsMs(
+                500,
+                5000,
+                500,
+                500
+            ).build()
+
+        val trackSelector = DefaultTrackSelector(playerView.context)
+        // It gets embedded captions from the video source
+        trackSelector.setParameters(trackSelector.buildUponParameters().setPreferredTextLanguage("en"))
+
+        player = ExoPlayer
+            .Builder(playerView.context)
+            .setTrackSelector(trackSelector)
+            .setLoadControl(loadControl)
+            .build()
+            .apply {
+                addListener(this@VideoPlayerExoPlayer2181Impl)
+                playWhenReady = autoPlay
+            }
+
+        playerView.preloadFirstFrame(media)
+        playerView.prepare(media, this@VideoPlayerExoPlayer2181Impl)
+
+        player?.videoScalingMode = C.VIDEO_SCALING_MODE_SCALE_TO_FIT
+
+        updateRepeatMode()
+        startProgressTimer()
+        // This is the MediaSource representing the media to be played.
+        val extractoryFactory =
+            DefaultExtractorsFactory().setConstantBitrateSeekingEnabled(true)
+        val uri = Uri.parse(videoUrl)
+
+        val mediaItemBuilder = MediaItem.Builder()
+            .setUri(uri)
+            .setCustomCacheKey(uri.buildUpon().clearQuery().build().toString())
+
+        // Sideloading captions. Keep it here just in case.
+        /*media.video?.captions?.videoCaption?.vtt?.let {
+            val uriSubtitle = Uri.parse(it)
+
+            val mediaItemSubtitle = MediaItem.Subtitle(uriSubtitle,
+                MimeTypes.TEXT_VTT,
+                "en",
+                C.SELECTION_FLAG_DEFAULT)
+
+            mediaItemBuilder.setSubtitles(mutableListOf(mediaItemSubtitle))
+        }*/
+
+        val mediaItem = mediaItemBuilder
+            .build()
+        val mediaSource = DefaultMediaSourceFactory(VideoCache.cacheDataSourceFactory, extractoryFactory).createMediaSource(mediaItem)
+
+        // Prepare the player with the source.
+        player?.setMediaSource(mediaSource)
+        player?.prepare()
+        stopListeningToDeviceVolume()
+        startListeningToDeviceVolume()
+
+    }
+
+    override fun destroyPlayer() {
+        player?.release()
+        player = null
+    }
+
+    override fun updateRepeatMode() {
+        player?.repeatMode =
+            if (repeatable) Player.REPEAT_MODE_ALL else Player.REPEAT_MODE_OFF
+    }
+
+    // endregion
+
+    // region Exoplayer listener
+
+    override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+        super.onMediaItemTransition(mediaItem, reason)
+        if (reason == Player.MEDIA_ITEM_TRANSITION_REASON_REPEAT) {
+            listeners.forEach {
+                it(GPHVideoPlayerState.Repeated)
+            }
+        }
+    }
+
+    override fun onPlaybackStateChanged(state: Int) {
+        super.onPlaybackStateChanged(state)
+        val stateStr: String
+        val videoPlaybackState: GPHVideoPlayerState
+        when (state) {
+            Player.STATE_READY -> {
+                stateStr = "STATE_READY"
+                videoPlaybackState = GPHVideoPlayerState.Ready
+            }
+            Player.STATE_BUFFERING -> {
+                stateStr = "STATE_BUFFERING"
+                videoPlaybackState = GPHVideoPlayerState.Buffering
+            }
+            Player.STATE_ENDED -> {
+                stateStr = "STATE_ENDED"
+                videoPlaybackState = GPHVideoPlayerState.Ended
+            }
+            Player.STATE_IDLE -> {
+                stateStr = "STATE_IDLE"
+                videoPlaybackState = GPHVideoPlayerState.Idle
+            }
+            else -> {
+                stateStr = "STATE_UNKNOWN"
+                videoPlaybackState = GPHVideoPlayerState.Unknown
+            }
+        }
+        Timber.d("onPlayerStateChanged $stateStr")
+        if (state == Player.STATE_ENDED) {
+            // make sure we send a final progress
+            player?.duration?.let {
+                updateProgress(it)
+            }
+        }
+        listeners.forEach {
+            it(videoPlaybackState)
+        }
+    }
+
+    override fun onIsLoadingChanged(isLoading: Boolean) {
+        super.onIsLoadingChanged(isLoading)
+        Timber.d("onLoadingChanged $isLoading")
+        if (isLoading) {
+            if (lastProgress > 0) {
+                Timber.d("restore seek $lastProgress")
+                player?.seekTo(lastProgress)
+                lastProgress = 0L
+            }
+        }
+    }
+
+    override fun onIsPlayingChanged(isPlaying: Boolean) {
+        Timber.d("onIsPlayingChanged ${media.id} $isPlaying")
+        if (isPlaying) {
+            listeners.forEach {
+                it(GPHVideoPlayerState.Playing)
+            }
+            playerView?.keepScreenOn = true
+        } else {
+            player?.playbackState?.let {
+                if (it != Player.STATE_ENDED) {
+                    onPlaybackStateChanged(it)
+                }
+            }
+            playerView?.keepScreenOn = false
+        }
+    }
+
+    override fun onTimelineChanged(timeline: Timeline, reason: Int) {
+        player?.duration?.let { duration ->
+            listeners.forEach {
+                it(GPHVideoPlayerState.TimelineChanged(duration))
+            }
+            if (duration > 0) {
+                if (media.userDictionary == null)
+                    media.userDictionary = HashMap()
+                media.userDictionary?.put(KEY_VIDEO_LENGTH, duration.toString())
+            }
+        }
+    }
+
+    override fun onPlayerError(error: PlaybackException) {
+        super.onPlayerError(error)
+        listeners.forEach {
+            it(GPHVideoPlayerState.Error(error.localizedMessage ?: "Error occurred"))
+        }
+    }
+
+    override fun onCues(cueGroup: CueGroup) {
+        listeners.forEach {
+
+            it(GPHVideoPlayerState.CaptionsTextChanged(if (cueGroup.cues.size > 0) cueGroup.cues[0].text.toString() else ""))
+        }
+    }
+
+    // endregion
+
+}

--- a/app/src/main/java/com/giphy/sdk/uidemo/feed/MessageFeedAdapter.kt
+++ b/app/src/main/java/com/giphy/sdk/uidemo/feed/MessageFeedAdapter.kt
@@ -5,15 +5,15 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.giphy.sdk.core.models.Media
+import com.giphy.sdk.ui.utils.GPHAbstractVideoPlayer
 import com.giphy.sdk.ui.utils.px
-import com.giphy.sdk.ui.views.GPHVideoPlayer
 import com.giphy.sdk.uidemo.R
 import com.giphy.sdk.uidemo.SettingsDialogFragment
 import com.giphy.sdk.uidemo.databinding.GifItemBinding
 import com.giphy.sdk.uidemo.databinding.MessageItemBinding
 
 class ClipsAdapterHelper {
-    lateinit var player: GPHVideoPlayer
+    lateinit var player: GPHAbstractVideoPlayer
     lateinit var clipsPlaybackSetting: SettingsDialogFragment.ClipsPlaybackSetting
 }
 
@@ -92,7 +92,7 @@ class MessageFeedAdapter(val items: MutableList<FeedDataItem>) : RecyclerView.Ad
         RecyclerView.ViewHolder(itemView) {
 
         lateinit var media: Media
-        lateinit var player: GPHVideoPlayer
+        lateinit var player: GPHAbstractVideoPlayer
 
         val viewBinding = GifItemBinding.bind(itemView)
 

--- a/clips.md
+++ b/clips.md
@@ -8,24 +8,72 @@ The Clips Library is built with all of the unforgettable quotes, cultural moment
 
 Integrating the GIPHY Clips SDK will allow your users to seamlessly express themselves with this new format, all while staying in the experience in your app. 
 
- 
 ### Requirements
 
 - GIPHY SDK v2.1.2 (or above)  
 - GIPHY Clips is available for integration into our community of messaging and social apps for users to search and share.  Clips is not approved to be integrated into creation experience where derivative works can be created. 
 
+### Setting Up ExoPlayer
 
-### Showing Clips in the GiphyViewController
+The GIPHY SDK uses [`ExoPlayer`](https://github.com/google/ExoPlayer) to power video playback. As of version v2.2.0 of the GIPHY SDK, ExoPlayer must be manually added as a dependency. See below for directions prior to v2.2.
 
-Add the new  `.clips`  `GPHContentType` to your `mediaTypeConfig` array. 
+<details>
+  <summary>SDK v2.1.x:</summary>
+The SDK has `Exoplayer` video cache setup.
+It's enabled by default: the `videoCacheMaxBytes` value must be greater than 0, otherwise, the SDK will skip cache initialization and [Clips](https://github.com/Giphy/giphy-android-sdk/blob/main/clips.md) won't work.
+
+```kotlin
+Giphy.configure(
+  videoCacheMaxBytes: 100 * 1024 * 1024
+)
+``` 
+</details>
+
+
+#### Using clips in SDK v2.2.0 (or above):
+
+We removed the `ExoPlayer` dependency as of version `2.2.0` because of issues resulting from versioning conflicts, and so developers not using the Clips content type in their GIPHY integration wouldn't have to adopt this dependency.
+
+Manually add the `ExoPlayer` dependency to your project like so:
+
+```
+implementation("com.google.android.exoplayer:exoplayer-core:2.18.1")
+implementation("com.google.android.exoplayer:exoplayer-ui:2.18.1")
+```
+
+Initialize the [VideoCache](https://github.com/Giphy/giphy-android-sdk/blob/main/app/src/main/java/com/giphy/sdk/uidemo/VideoPlayer/VideoCache.kt) to use `Clips`:
+
+```
+VideoCache.initialize(this, 100 * 1024 * 1024)
+Giphy.configure(this, YOUR_API_KEY, true)
+```
+
+Provide a `GPHAbstractVideoPlayer` implementation, which is required by the GIPHY SDK to play Clips.
+
+We prepared an example based on the `ExoPlayer` 2.18.1 version - this may need to be modified for different versions of ExoPlayer:
+- [VideoPlayerExoPlayer2181Impl](https://github.com/Giphy/giphy-android-sdk/blob/main/app/src/main/java/com/giphy/sdk/uidemo/VideoPlayer/VideoPlayerExoPlayer2181Impl.kt)
+
+```
+ val dialog = GiphyDialogFragment.newInstance(
+    settings.copy(selectedContentType = contentType),
+    videoPlayer = { playerView, repeatable, showCaptions ->
+        VideoPlayerExoPlayer2181Impl(playerView, repeatable, showCaptions)
+    }
+ )
+```
+
+
+### Showing Clips in the GiphyDialogFragment
+
+Add the new  `.clips`  `GPHContentType` to your `mediaTypeConfig` array.
 ```
 settings.mediaTypeConfig = arrayOf(GPHContentType.gif, GPHContentType.sticker, GPHContentType.clips) 
 ```
- 
+
 ### New MediaType: .video
 
-The new  `video` type signifies that a `Media` instance is a GIPHY Clip, and is intended to be played back as a video with sound. 
- 
+The new  `video` type signifies that a `Media` instance is a GIPHY Clip, and is intended to be played back as a video with sound.
+
 ```
 if (media.type == MediaType.video) {
  
@@ -34,22 +82,28 @@ if (media.type == MediaType.video) {
 when (mediaType) {                
     MediaType.video -> println("clip")
 ```
- 
- ### GPHVideoPlayer + GPHVideoPlayerView
- 
- Playing back a Clips video asset in your Android app is easy thanks to Google’s `ExoPlayer`, an application level media player for Android. 
- 
- Giphy SDK already comes with `ExoPlayer` dependency and provides a wrapper around `ExoPlayer` to ease `Clips` integration:
- 
- Create `GPHVideoPlayer` instance.
- 
- Attach the player to `GPHVideoPlayerView`. There are two ways to do that:
- - using `GPHVideoPlayer` constructor
- - pass as param of `GPHVideoPlayer.loadMedia` function.
-  
- Prepare the player with a `Media` item to play: `GPHVideoPlayer.loadMedia(media)`
- 
- Release the player by calling `GPHVideoPlayer.onDestroy()` func when done.
+
+---
+
+<details>
+  <summary>Using clips in SDK v2.1.x:</summary>
+
+
+#### GPHVideoPlayer + GPHVideoPlayerView
+
+Playing back a Clips video asset in your Android app is easy thanks to Google’s `ExoPlayer`, an application level media player for Android.
+
+Giphy SDK already comes with `ExoPlayer` dependency and provides a wrapper around `ExoPlayer` to ease `Clips` integration:
+
+Create `GPHVideoPlayer` instance.
+
+Attach the player to `GPHVideoPlayerView`. There are two ways to do that:
+- using `GPHVideoPlayer` constructor
+- pass as param of `GPHVideoPlayer.loadMedia` function.
+
+Prepare the player with a `Media` item to play: `GPHVideoPlayer.loadMedia(media)`
+
+Release the player by calling `GPHVideoPlayer.onDestroy()` func when done.
 
 
 Create and load a `GPHVideoPlayer + GPHVideoPlayerView` with a `GPHMedia`
@@ -79,76 +133,101 @@ val playerView = GPHVideoPlayerView(context)
 val player = GPHVideoPlayer(null, true)
 player.loadMedia(media, view = playerView)
 ```
+</details>
 
-### Sending Clips & Renditions 
+---
 
-As with sending / storing GIFs and Stickers, it's best practice to use GIPHY IDs to represent GIPHY Clips, rather than asset urls, and use the `gifByID` or `gifsByID` endpoints to retrieve the associated `Media`(s). 
+#### To use GPHAbstractVideoPlayer + GPHVideoPlayerView in grids
+
+Attach the player to `GPHVideoPlayerView`. There are two ways to do that:
+- using `GPHAbstractVideoPlayer` implementation constructor.
+```
+  videoPlayer = VideoPlayerExoPlayer2181Impl(videoPlayerView, true)
+ ```
+- pass as param of `GPHAbstractVideoPlayer.loadMedia` function.
+```
+  player.loadMedia(media, view = viewBinding.videoPlayerView)
+```  
+
+Prepare the player with a `Media` item to play: `GPHAbstractVideoPlayer.loadMedia(media)`
+```
+  val playerView = GPHVideoPlayerView(context)  
+  val videoPlayer = VideoPlayerExoPlayer2181Impl(null, true)
+  videoPlayer.loadMedia(media, view = viewBinding.videoPlayerView)
+  
+  OR
+  
+  val playerView = GPHVideoPlayerView(context)
+  val videoPlayer = VideoPlayerExoPlayer2181Impl(videoPlayerView, true)
+  player.loadMedia(media)
+```  
+
+Release the player by calling `GPHAbstractVideoPlayer.onDestroy()`
+```  
+  override fun onDestroyView() {
+    super.onDestroyView()
+    videoPlayer?.onDestroy()
+  }
+```  
+
+Pause, Resume, Mute, Unmute:
+
+```
+GPHAbstractVideoPlayer.onPause()  
+GPHAbstractVideoPlayer.onResume()  
+GPHAbstractVideoPlayer.setVolume(audioVolume: 0) 
+GPHAbstractVideoPlayer.setVolume(audioVolume: 1) 
+```
+
+To subscribe to `GPHAbstractVideoPlayer` events:
+```
+GPHAbstractVideoPlayer.addListener(GPHPlaybackStateListener)
+```
+
+It's preferable to use only one `GPHAbstractVideoPlayer` implementation instance and share it between `GPHVideoPlayerView`(s):
+```
+val playerView = GPHVideoPlayerView(context)
+val player = VideoPlayerExoPlayer2181Impl(null, true)
+player.loadMedia(media, view = playerView)
+```
+
+---
+
+### Sending Clips & Renditions
+
+As with sending / storing GIFs and Stickers, it's best practice to use GIPHY IDs to represent GIPHY Clips, rather than asset urls, and use the `gifByID` or `gifsByID` endpoints to retrieve the associated `Media`(s).
 
 Video urls (`.mp4`) may be accessed directly within the `video` property (with type `Video`) of the encompassing `Media`.
 
 
-### Rendition Limitations 
+### Rendition Limitations
 
-Certain renditions (cases of the `RenditionType` enum) are not available for Clips. These include: 
+Certain renditions (cases of the `RenditionType` enum) are not available for Clips. These include:
 
-- `preview` 
-- `previewGif` 
-- `looping` 
-- `fixedWidthSmall` 
+- `preview`
+- `previewGif`
+- `looping`
+- `fixedWidthSmall`
 - `fixedWidthSmallStill`
-- `fixedHeightSmall` 
-- `fixedHeighSmallStill` 
+- `fixedHeightSmall`
+- `fixedHeighSmallStill`
 - `downsizedSmall`
 - `downsizedStill`
-- `downsized` 
+- `downsized`
 
-As a result, if you set the `renditionType` property of `GPHSettings` or `GiphyGridView` to any of these, clips previews may not play back correctly in the grid. 
+As a result, if you set the `renditionType` property of `GPHSettings` or `GiphyGridView` to any of these, clips previews may not play back correctly in the grid.
 
-To account for this limitation, we created a new property specifically for clips call `clipsPreviewRenditionType` which is available as a property of both `GPHSettings` and `GiphyGridView`. Setting this property to one of the above `RenditionType` options will throw an exception. 
+To account for this limitation, we created a new property specifically for clips call `clipsPreviewRenditionType` which is available as a property of both `GPHSettings` and `GiphyGridView`. Setting this property to one of the above `RenditionType` options will throw an exception.
 
-As with `renditionType` the default for `clipsPreviewRenditionType` is the `RenditionType` option  `.fixedWidth`. 
+As with `renditionType` the default for `clipsPreviewRenditionType` is the `RenditionType` option  `.fixedWidth`.
 
-### Showing Clips in the GiphyGridView 
+### Showing Clips in the GiphyGridView
 
-Display silent Clips previews in the `GiphyGridView` collection view in the same way you would with GIFs and stickers. 
+Display silent Clips previews in the `GiphyGridView` collection view in the same way you would with GIFs and stickers.
 
 ```
 val trending = GPHContent.trendingVideos  
 val search = GPHContent.searchQuery("hello", MediaType.video)
-``` 
-
-We strongly reccomend providing your users with the option to play back the clip, including audio, before enabling them to send or share the clip asset, as is the case with the existing experience offered by the `GiphyDialogFragment`. This can be accomplished by presenting a `GPHVideoPlayerView` following user selection of a clip preview. 
-
-### VideoPlayer + VideoPlayerView
-
-`VideoPlayer` and `VideoPlayerView` are a generic alternative to the `GPHVideoPlayer` and `GPHVideoPlayerView` already included in the SDK.
-Note: You can find these files in the example app - they are not a part of the SDK.
-
-We're providing source code for the player as it may be useful for developers that want to customize the design as well as the innerworkings.
-
-It may also be a resource for GIPHY integration partners who are interested in adopting the Clips content type, as this video player code is intended to be independent of SDK components.
-
-#### Surfaceview and TextureView
-By default, the video is rendered on an android SurfaceView as it's more performant. If you need to use the potential of TextureView, you can just replace it yourself like so:
 ```
-VideoPlayer.kt:
-+        fun setVideoTextureView(textureView: TextureView?) {
-+            player?.setVideoTextureView(textureView)
-+        }
 
-
-VideoPlayerView.kt:
--        player.setVideoSurfaceView(viewBinding.surfaceView)
-+        player.setVideoTextureView(viewBinding.textureView)
-
--        viewBinding.surfaceView.layoutParams = params
-+        viewBinding.textureView.layoutParams = params
-
-
-video_player_view.xml:
--    <SurfaceView
--        android:id="@+id/surfaceView"
-+    <TextureView
-+        android:id="@+id/textureView"
-
-```
+We strongly recommend providing your users with the option to play back the clip, including audio, before enabling them to send or share the clip asset, as is the case with the existing experience offered by the `GiphyDialogFragment`. This can be accomplished by presenting a `GPHVideoPlayerView` following user selection of a clip preview.


### PR DESCRIPTION
- Addresses Issue #170 and #187: We removed the ExoPlayer dependency as of version 2.2.0, and so developers not using the Clips content type in their GIPHY integration wouldn't have to adopt this dependency.